### PR TITLE
us1062: Fix number of items being displayed per page for education items

### DIFF
--- a/Dashboard/va.gov.artemis.commands/Dsio/Education/DsioGetEducationItemsCommand.cs
+++ b/Dashboard/va.gov.artemis.commands/Dsio/Education/DsioGetEducationItemsCommand.cs
@@ -25,7 +25,7 @@ namespace VA.Gov.Artemis.Commands.Dsio.Education
             string size = (pageSize > 0) ? pageSize.ToString() : "";
             string pg = (page > 0) ? page.ToString() : ""; 
             
-            this.CommandArgs = new object[] { size, pg, category, type, ien, sort.ToString() };            
+            this.CommandArgs = new object[] { pg, size, category, type, ien, sort.ToString() };            
         }
 
         protected override void ProcessStartData()


### PR DESCRIPTION
The number of education items that are displayed per page does not correspond to the page size. The table of Education items shows different number of items on each page instead of a fixed number of items per page. Page 1 shows 1 item, page 2 shows 2 items, and so on. It seems that the number of items that are shown per page corresponds to the page number.