### PR TITLE
us1067: Fix patient education items being added to Select Patient Education Items Screen

### DIFF
--- a/Dashboard/va.gov.artemis.commands/Dsio/Education/DsioGetPatientEducationCommand.cs
+++ b/Dashboard/va.gov.artemis.commands/Dsio/Education/DsioGetPatientEducationCommand.cs
@@ -36,7 +36,7 @@ namespace VA.Gov.Artemis.Commands.Dsio.Education
             //•	ToDate – DateTime – A date representing the newest item to return – Not Required
             //•	Type – List of types (Discussion, Printed, Link, etc.) – Not Required
 
-            this.CommandArgs = new object[] { dfn, ien, itemsPerPage.ToString(), page.ToString(), fromDate, toDate, itemType };
+            this.CommandArgs = new object[] { dfn, ien, page.ToString(), itemsPerPage.ToString(), fromDate, toDate, itemType };
         }
 
         protected override void ProcessLine(string line)


### PR DESCRIPTION
When selected Education Items on Select Patient Education Items screen are saved, they are not added to the table of patient Education Items. This fix allows for the items to be displayed.