### PR TITLE
us1075: Update GravidaPara Summary correctly on the Pregnancy History Screen

### DIFF
--- a/Dashboard/va.gov.artemis.ui.data/Models/Pregnancy/PregnancyHistory.cs
+++ b/Dashboard/va.gov.artemis.ui.data/Models/Pregnancy/PregnancyHistory.cs
@@ -141,20 +141,28 @@ namespace VA.Gov.Artemis.UI.Data.Models.Pregnancy
                 string term = (this.TermBirths.HasValue) ? this.TermBirths.ToString() : "?";
                 string preterm = (this.PretermBirths.HasValue) ? this.PretermBirths.ToString() : "?";
 
+                //compute element 3 of the Gravida/Para Summary
                 int element3 = 0;
-
-                if (this.SpontaneousAbortions.HasValue)
+                Boolean element3Known = false;
+                if (this.SpontaneousAbortions.HasValue) {
                     element3 = this.SpontaneousAbortions.Value;
-
+                    element3Known = true;
+                }
                 if (this.PregnancyTerminations.HasValue)
+                {
                     element3 += this.PregnancyTerminations.Value;
-
+                    element3Known = true;
+                }
                 if (this.EctopicPregnancies.HasValue)
+                {
                     element3 += this.EctopicPregnancies.Value;
+                    element3Known = true;
+                }
+                string element3ForDisplay = element3Known ? element3.ToString() : "?";
 
                 string living = (this.LivingChildren.HasValue) ? this.LivingChildren.ToString() : "?";
 
-                returnVal = string.Format("P{0}{1}{2}{3}", term, preterm, element3, living); 
+                returnVal = string.Format("P{0}{1}{2}{3}", term, preterm, element3ForDisplay, living); 
 
                 return returnVal;
             }

--- a/Dashboard/va.gov.artemis.ui/Views/Pregnancy/EditPregnancyHistory.cshtml
+++ b/Dashboard/va.gov.artemis.ui/Views/Pregnancy/EditPregnancyHistory.cshtml
@@ -119,20 +119,33 @@
         });
 
         $('.gp').change(function () {
-            var result = 'G' + $('#History_TotalPregnancies').val();
-            result += ' P' + $('#History_TermBirths').val();
-            result += $('#History_PretermBirths').val();
-            
-            var a = +$('#History_SpontaneousAbortions').val();
-            var b = +$('#History_PregnancyTerminations').val();
-            var c = +$('#History_EctopicPregnancies').val();
 
-            var sum = a + b + c;
+            var totalPregnancies = $('#History_TotalPregnancies').val() ? $('#History_TotalPregnancies').val() : '?';
+            var termBirths = $('#History_TermBirths').val() ? $('#History_TermBirths').val() : '?';
+            var pretermBirths = $('#History_PretermBirths').val() ? $('#History_PretermBirths').val() : '?';
+            var livingChildren = $('#History_LivingChildren').val() ? $('#History_LivingChildren').val() : '?';
 
-            result += sum.toString();
+            //compute element 3 of parity
+            var element3 = 0;
+            var spontaneousAbortions = $('#History_SpontaneousAbortions').val();
+            if (spontaneousAbortions) {
+                element3 = +spontaneousAbortions;
+            }
+            var pregnancyTerminations = $('#History_PregnancyTerminations').val();
+            if (pregnancyTerminations) {
+                element3 += +pregnancyTerminations;
+            }
+            var ectopicPregnancies = $('#History_EctopicPregnancies').val();
+            if (ectopicPregnancies) {
+                element3 += +ectopicPregnancies;
+            }
+            if (!spontaneousAbortions && !pregnancyTerminations && !ectopicPregnancies) {
+                element3 = '?';
+            }
 
-            result += $('#History_LivingChildren').val();
-
+            var gravidity = 'G' + totalPregnancies;
+            var parity = 'P' + termBirths + pretermBirths + element3 + livingChildren;
+            var result = gravidity + ' ' + parity;     
             $('#History_GravidaPara').text(result);
         });
 


### PR DESCRIPTION
 When any of the Pregnancy History fields is empty, Gravida/Para Summary field at the bottom of the screen is not updated correctly.