### PR TITLE
us1063: Fix Pregnancy History screen save process

### DIFF
--- a/Dashboard/va.gov.artemis.ui.data/Brokers/Pregnancy/PregnancyRepository.cs
+++ b/Dashboard/va.gov.artemis.ui.data/Brokers/Pregnancy/PregnancyRepository.cs
@@ -481,7 +481,7 @@ namespace VA.Gov.Artemis.UI.Data.Brokers.Pregnancy
             {
                 //The fields need to be saved even if they have empty values.
                 //If the user decides that a previously saved field has erroneous data
-                //and the new value is unknown, then this should be relflected as such.
+                //and the new value is unknown, then this should be reflected as such.
                 if (newObservation.Value != null)
                 {
                     // *** If we have previous entries ***

--- a/Dashboard/va.gov.artemis.ui.data/Brokers/Pregnancy/PregnancyRepository.cs
+++ b/Dashboard/va.gov.artemis.ui.data/Brokers/Pregnancy/PregnancyRepository.cs
@@ -479,13 +479,15 @@ namespace VA.Gov.Artemis.UI.Data.Brokers.Pregnancy
             // *** Loop through all the observations ***
             foreach (Observation newObservation in pregnancyHistory.Observations.Values)
             {
-                if (!string.IsNullOrWhiteSpace(newObservation.Value)) // *** Add if there's something there
+                //The fields need to be saved even if they have empty values.
+                //If the user decides that a previously saved field has erroneous data
+                //and the new value is unknown, then this should be relflected as such.
+                if (newObservation.Value != null)
                 {
                     // *** If we have previous entries ***
                     if (origHist != null)
                     {
                         // *** Compare current with previous and only save if different ***
-
                         string origVal = origHist.GetValue(newObservation.Code);
 
                         if (origVal == null)

--- a/Dashboard/va.gov.artemis.ui/Views/Pregnancy/EditPregnancyHistory.cshtml
+++ b/Dashboard/va.gov.artemis.ui/Views/Pregnancy/EditPregnancyHistory.cshtml
@@ -107,7 +107,7 @@
         <div class="col-md-10 col-offset-2">
             <div class="pull-right">
                 <button type="button" class="btn btn-default" onclick="location.href='@Model.ReturnUrl'">Cancel</button>
-                <button type="submit" class="btn btn-primary">Save</button>
+                <button type="submit" class="btn btn-primary" id="saveBtn">Save</button>
             </div>
         </div>
     </div>
@@ -185,6 +185,10 @@
             if (!alert){
                 $("#alertId").attr("hidden", "hidden");
                 $("#alertId").text("");
+                $("#saveBtn").removeAttr("disabled");
+            }
+            else {
+                $("#saveBtn").attr("disabled", "disabled");
             }
             $('#History_GravidaPara').text(result);
         });


### PR DESCRIPTION
Saving the pregnancy history only after the fields are validated. Empty fields are allowed, being marked in the summary with "?", the equivalent of "Unknown". 